### PR TITLE
fixes py3-specific issues in deconvolution processing

### DIFF
--- a/ms_deisotope/deconvolution.py
+++ b/ms_deisotope/deconvolution.py
@@ -1146,7 +1146,7 @@ class PeakDependenceGraphDeconvoluterBase(ExhaustivePeakSearchDeconvoluterBase):
         results = hold
 
         n = len(results)
-        stop = max(min(n / 2, 100), 10)
+        stop = max(min(n // 2, 100), 10)
         if n == 0:
             return 0
 

--- a/ms_deisotope/envelope_statistics.py
+++ b/ms_deisotope/envelope_statistics.py
@@ -35,4 +35,7 @@ def average_signal_to_noise(envelope):
 
 
 def weighted_average(values, weights):
+    # We need to traverse weights twice, therefore convert it to a list
+    # as a generator (i.e. py3's map) would always have sum(weights) == 0
+    weights = list(weights)
     return sum(v * w for v, w in zip(values, weights)) / float(sum(weights))


### PR DESCRIPTION
Fairly self explanatory, see the diff in the code.
Py3 defaults to float division so `n/2` would return a float which is later used in `range` function that throws an error cause it knows not what to do with it.

Similarly, in weighted average calculation, `weights` is a `map` object in py3.
The implementation of `weighted_average` tries to traverse this object twice which means that the second time it traverses it (namely when computing the `sum`), the object is empty.
Thus the sum is always 0 and we get a division-by-zero exception.
