### PR TITLE
Sign of the charge_range based on polarity

### DIFF
--- a/src/ms_deisotope/deconvolution/api.py
+++ b/src/ms_deisotope/deconvolution/api.py
@@ -64,7 +64,7 @@ def deconvolute_peaks(peaklist: PeakListTypes,
         Parameters to use to initialize the deconvoluter instance produced by
         ``deconvoluter_type``
     charge_range : tuple of integers, optional
-        The range of charge states to consider. The range is inclusive. Sensitive to sign of the charge/polairty.
+        The range of charge states to consider. The range is inclusive. Sensitive to sign of the charge/polarity.
     error_tolerance : float, optional
         PPM error tolerance to use to match experimental to theoretical peaks
     priority_list : list, optional
@@ -136,10 +136,12 @@ def deconvolute_peaks(peaklist: PeakListTypes,
     decon_config.setdefault("scale_method", SCALE_METHOD)
     decon_config.setdefault("use_quick_charge", use_quick_charge)
 
-    #Update the charge range with the proper sign, considering the polarity when the poalrity attaribute is defined!
+    # Update the charge range with the proper sign, considering the polarity when
+    # the `polarity` attribute is defined on `peaklist`.
     if hasattr(peaklist, 'polarity'):
-        if peaklist.polarity < 0 and max(charge_range) > 0:
-            charge_range = tuple(c * peaklist.polarity for c in charge_range)
+        polarity = int(peaklist.polarity)
+        if polarity < 0 and max(charge_range) > 0:
+            charge_range = tuple(c * polarity for c in charge_range)
 
     peaklist = prepare_peaklist(peaklist)
 

--- a/src/ms_deisotope/deconvolution/api.py
+++ b/src/ms_deisotope/deconvolution/api.py
@@ -64,7 +64,7 @@ def deconvolute_peaks(peaklist: PeakListTypes,
         Parameters to use to initialize the deconvoluter instance produced by
         ``deconvoluter_type``
     charge_range : tuple of integers, optional
-        The range of charge states to consider. The range is inclusive.
+        The range of charge states to consider. The range is inclusive. Sensitive to sign of the charge/polairty.
     error_tolerance : float, optional
         PPM error tolerance to use to match experimental to theoretical peaks
     priority_list : list, optional
@@ -143,6 +143,11 @@ def deconvolute_peaks(peaklist: PeakListTypes,
 
     if verbose_priorities or verbose:
         decon.verbose = True
+
+    #Update the charge range with the proper sign, considering the polarity when the poalrity attaribute is defined!
+    if hasattr(peaklist, 'polarity'):
+        if peaklist.polarity < 0 and max(charge_range) > 0:
+            charge_range = tuple(c * peaklist.polarity for c in charge_range)
 
     priority_list_results = []
     for p in priority_list:

--- a/src/ms_deisotope/deconvolution/api.py
+++ b/src/ms_deisotope/deconvolution/api.py
@@ -136,18 +136,17 @@ def deconvolute_peaks(peaklist: PeakListTypes,
     decon_config.setdefault("scale_method", SCALE_METHOD)
     decon_config.setdefault("use_quick_charge", use_quick_charge)
 
-    peaklist = prepare_peaklist(peaklist)
-
-    decon = deconvoluter_type(peaklist=peaklist, **decon_config)
-
-
-    if verbose_priorities or verbose:
-        decon.verbose = True
-
     #Update the charge range with the proper sign, considering the polarity when the poalrity attaribute is defined!
     if hasattr(peaklist, 'polarity'):
         if peaklist.polarity < 0 and max(charge_range) > 0:
             charge_range = tuple(c * peaklist.polarity for c in charge_range)
+
+    peaklist = prepare_peaklist(peaklist)
+
+    decon = deconvoluter_type(peaklist=peaklist, **decon_config)
+
+    if verbose_priorities or verbose:
+        decon.verbose = True
 
     priority_list_results = []
     for p in priority_list:


### PR DESCRIPTION
Based on the `polarity` of the scan when available, the `charge_range` attribute in `deconvolute_peaks` is now automatically updated. This is specially important when the polarity is negative. 

This makes the behavior of the calling the function `deconvolute_peaks` on a scan or a pearliest object consistent with directly calling the method `deconvolute` defined on the class. The behavior was inconsistent earlier because such an update of the sign of the `charge_range` was being performed in the `deconvolute` method.